### PR TITLE
Add learned temperature support for InfoNCE loss

### DIFF
--- a/lib/loss.py
+++ b/lib/loss.py
@@ -29,9 +29,10 @@ class InfoNCE(nn.Module):
         reduction="mean",
         negative_mode="unpaired",
         symmetric_loss=False,
+        learn_temperature=False,
     ):
         super().__init__()
-        self.temperature = temperature
+        self.temperature = nn.Parameter(torch.tensor(temperature)) if learn_temperature else temperature
         self.reduction = reduction
         self.negative_mode = negative_mode
         self.symmetric_loss = symmetric_loss

--- a/lib/train_modules.py
+++ b/lib/train_modules.py
@@ -23,7 +23,7 @@ class MultimodalContrastiveLearningModule(pl.LightningModule):
         self.target_modalities = target_modalities
         self.list_modalities = modality_to_encoder.keys()
 
-        self.loss = InfoNCE(symmetric_loss=True)
+        self.loss = InfoNCE(symmetric_loss=True, learn_temperature=True)
 
         if "imu" in self.list_modalities:
             self.imu_encoder = modality_to_encoder["imu"]


### PR DESCRIPTION
# Description

As mentioned in the [loss file](https://github.com/facebookresearch/imu2clip/blob/e42564e989454c4cbdb58ec82d8e28711d506787/lib/loss.py#L130), I have modified the loss by making temperature a learned parameter of the model rather than a fixed hyperparameter. Have benchmarked the results against the originally reported and locally reproduced results. 

Fixes # (issue)

## Type of change

Please check the options that are relevant.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [x] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change
- [ ] Datasets Release
- [ ] Models Release

## Type of requested review

- [x] I want a thorough review of the implementation.
- [ ] I want a high level review. 
- [ ] I want a deep design review.

## Before and After

Please find the reproduced results below:

| Metric   |   Local (learned_temperature=False)|   Local (learned_temperature=True) |   Reported Number |
|:---------|---------------------:|----------------------:|------------------:|
| MRR I &rarr; T  |               0.104 |                0.123  |            0.123 |
| R@1 I &rarr; T |               3.99 |                4.35 |            5.21   |
| R@10 I &rarr; T |               22.1  |                28.26 |            25.00 |
| R@50 I &rarr; T |               64.13 |                67.03 |          60.42      |
| MRR T &rarr; I |               0.111 |                0.1156 |            0.143  |
| R@1 T &rarr; I  |               3.99 |                3.62 |            7.29 |
| R@10 T &rarr; I |               25.36 |                26.81 |            28.82 |
| R@50 T &rarr; I |               65.22 |                69.20  |            60.07 |

# Testing

Have tested against the original implementation and provided comparison above. 

# Checklist:

- [x] I have performed manual end-to-end testing of the feature in my environment.
- [ ] I have added Docstrings and comments to the code.
- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added relevant collaborators to review the PR before merge.